### PR TITLE
Add Cog config and demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is the official repository of **EMOPIA: A Multi-Modal Pop Piano Dataset For
 
 - [Paper on Arxiv](https://arxiv.org/abs/2108.01374)
 - [Demo Page](https://annahung31.github.io/EMOPIA/)
+- [Interactive demo and Docker image on Replicate](https://replicate.ai/annahung31/emopia)
 - [Dataset at Zenodo](https://zenodo.org/record/5090631#.YPPo-JMzZz8)
 
 * Note: We release the transcribed MIDI files. As for the audio part, due to the copyright issue, we will only release the YouTube ID of the tracks and the timestamp of them. You might use [open source crawler](https://github.com/ytdl-org/youtube-dl) to get the audio file.

--- a/cog.yaml
+++ b/cog.yaml
@@ -1,0 +1,22 @@
+predict: "predict.py:Predictor"
+build:
+  gpu: true
+  system_packages:
+    - "ffmpeg"
+    - "fluidsynth"
+  python_packages:
+    - "torch==1.7.0"
+    - "scikit-learn==0.24.1"
+    - "seaborn==0.11.1"
+    - "numpy==1.19.5"
+    - "miditoolkit==0.1.14"
+    - "pandas==1.1.5"
+    - "tqdm==4.62.2"
+    - "matplotlib==3.4.3"
+    - "scipy==1.7.1"
+    - "midiSynth==0.3"
+    - "wheel==0.37.0"
+    - "ipdb===0.13.9"
+    - "pyfluidsynth==1.3.0"
+  pre_install:
+    - "pip install pytorch-fast-transformers==0.4.0"  # needs to be installed after the main pip install

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,90 @@
+# based on workspace/transformer/generate.ipynb
+
+import subprocess
+from pathlib import Path
+import tempfile
+import os
+import pickle
+import sys
+import torch
+import numpy as np
+from midiSynth.synth import MidiSynth
+import cog
+
+sys.path.insert(0, "workspace/transformer")
+from utils import write_midi
+from models import TransformerModel
+
+
+EMOTIONS = {
+    "High valence, high arousal": 1,
+    "Low valence, high arousal": 2,
+    "Low valence, low arousal": 3,
+    "High valence, low arousal": 4,
+}
+
+
+class Predictor(cog.Predictor):
+    def setup(self):
+        print("Loading dictionary...")
+        path_dictionary = "dataset/co-representation/dictionary.pkl"
+        with open(path_dictionary, "rb") as f:
+            self.dictionary = pickle.load(f)
+        event2word, self.word2event = self.dictionary
+
+        n_class = []  # num of classes for each token
+        for key in event2word.keys():
+            n_class.append(len(event2word[key]))
+        n_token = len(n_class)
+
+        print("Loading model...")
+        path_saved_ckpt = "exp/pretrained_transformer/loss_25_params.pt"
+        self.net = TransformerModel(n_class, is_training=False)
+        self.net.cuda()
+        self.net.eval()
+
+        self.net.load_state_dict(torch.load(path_saved_ckpt))
+
+        self.midi_synth = MidiSynth()
+
+    @cog.input(
+        "emotion",
+        type=str,
+        default="High valence, high arousal",
+        options=EMOTIONS.keys(),
+        help="Emotion to generate for",
+    )
+    @cog.input("seed", type=int, default=-1, help="Random seed, -1 for random")
+    def predict(self, emotion, seed):
+        if seed < 0:
+            seed = int.from_bytes(os.urandom(2), "big")
+        torch.manual_seed(seed)
+        np.random.seed(seed)
+        print(f"Prediction seed: {seed}")
+
+        out_dir = Path(tempfile.mkdtemp())
+        midi_path = out_dir / "out.midi"
+        wav_path = out_dir / "out.wav"
+        mp3_path = out_dir / "out.mp3"
+
+        emotion_tag = EMOTIONS[emotion]
+        res, _ = self.net.inference_from_scratch(
+            self.dictionary, emotion_tag, n_token=8
+        )
+        try:
+            write_midi(res, str(midi_path), self.word2event)
+            self.midi_synth.midi2audio(str(midi_path), str(wav_path))
+            subprocess.check_output(
+                [
+                    "ffmpeg",
+                    "-i",
+                    str(wav_path),
+                    "-af",
+                    "silenceremove=1:0:-50dB,aformat=dblp,areverse,silenceremove=1:0:-50dB,aformat=dblp,areverse",  # strip silence
+                    str(mp3_path),
+                ],
+            )
+            return mp3_path
+        finally:
+            midi_path.unlink(missing_ok=True)
+            wav_path.unlink(missing_ok=True)


### PR DESCRIPTION
Hi @annahung31!

First of all, I'm really impressed with EMOPIA's generation capabilities, the generated samples are very coherent!

This pull request makes it possible to run EMOPIA in an interactive web interface on Replicate: https://replicate.ai/annahung31/emopia

Replicate runs a Docker image, built from the included cog.yaml file by an open source tool called [Cog](https://github.com/replicate/cog). That Docker image can be pulled by others as well, so people can run your model on the command line without having to install Python dependencies.

One question: I'm not 100% sure I've got the emotion tags right. Is this correct?
* Emotion tag 1 == High valence, high arousal
* Emotion tag 2 == Low valence, high arousal
* Emotion tag 3 == Low valence, low arousal
* Emotion tag 4 == High valence, low arousal

If you click the "Sign in with GitHub" button on Replicate you can edit the description and add more examples, and we'll feature your model on the Explore page so more people find out about it 😊

![image](https://user-images.githubusercontent.com/713993/131176535-2a42605a-80f0-47be-a8e8-60db83bdfabc.png)

In case you're wondering who I am, I'm from [Replicate](https://replicate.ai/home), where we're trying to make machine learning reproducible. I did my PhD in source separation and often struggled to get baselines running, so we're trying to fix that by adding Docker images and demo pages to models we really like.